### PR TITLE
Revert "Add updated System.Drawing.Common to fix CVE"

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/OrchardCore.DataProtection.Azure.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/OrchardCore.DataProtection.Azure.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-  <PackageReference Include="System.Drawing.Common" Version="5.0.3"/>
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" />
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCore.Data.YesSql.csproj
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCore.Data.YesSql.csproj
@@ -23,7 +23,6 @@
   </ItemGroup>
 
   <ItemGroup>
-  <PackageReference Include="System.Drawing.Common" Version="5.0.3"/>
     <PackageReference Include="YesSql" />
   </ItemGroup>
 


### PR DESCRIPTION
This reverts commit 0cb493290d08793fd595ff8ceda1f93d58d05b01.

It is not needed as we already reference 6.0.0 of this library and this change causes package downgrade warnings.