### PR TITLE
Update packages and fix errors to get successful builds again.

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -29,30 +29,31 @@
     <PackageManagement Include="Jint" Version="3.0.2" />
     <PackageManagement Include="JsonPath.Net" Version="1.0.0" />
     <PackageManagement Include="HtmlSanitizer" Version="8.1.860-beta" />
-    <PackageManagement Include="Irony.Core" Version="1.0.7" />
+    <PackageManagement Include="Irony" Version="1.5.1" />
     <PackageManagement Include="libphonenumber-csharp" Version="8.13.34" />
     <PackageManagement Include="Lorem.Universal.NET" Version="4.0.80" />
     <PackageManagement Include="Lucene.Net" Version="4.8.0-beta00016" />
     <PackageManagement Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00016" />
     <PackageManagement Include="Lucene.Net.QueryParser" Version="4.8.0-beta00016" />
     <PackageManagement Include="Lucene.Net.Spatial" Version="4.8.0-beta00016" />
-    <PackageManagement Include="MailKit" Version="4.4.0" />
+    <PackageManagement Include="MailKit" Version="4.7.0" />
     <PackageManagement Include="Markdig" Version="0.36.2" />
     <PackageManagement Include="MessagePack" Version="2.2.60" />
-    <PackageManagement Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageManagement Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageManagement Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <PackageManagement Include="Microsoft.Extensions.Http.Resilience" Version="8.3.0" />
-    <PackageManagement Include="Microsoft.Identity.Web" Version="2.17.4" />
-    <PackageManagement Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.34.0" />
+    <PackageManagement Include="Microsoft.Identity.Web" Version="2.20.0" />
+    <PackageManagement Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.35.0" />
     <PackageManagement Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageManagement Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageManagement Include="MimeKit" Version="4.4.0" />
+    <PackageManagement Include="MimeKit" Version="4.7.0" />
     <PackageManagement Include="MiniProfiler.AspNetCore.Mvc" Version="4.3.8" />
     <PackageManagement Include="Moq" Version="4.20.70" />
     <PackageManagement Include="ncrontab" Version="3.3.3" />
     <PackageManagement Include="NEST" Version="7.17.5" />
     <PackageManagement Include="NJsonSchema" Version="11.0.0" />
     <PackageManagement Include="NLog.Web.AspNetCore" Version="5.3.8" />
+    <PackageManagement Include="Npgsql" Version="8.0.3" />
     <PackageManagement Include="NodaTime" Version="3.1.11" />
     <PackageManagement Include="OpenIddict.Core" Version="5.4.0" />
     <PackageManagement Include="OpenIddict.Server.AspNetCore" Version="5.4.0" />
@@ -64,20 +65,21 @@
     <PackageManagement Include="PdfPig" Version="0.1.8" />
     <PackageManagement Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageManagement Include="Shortcodes" Version="1.3.3" />
-    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="3.1.1" />
+    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="3.1.2" />
     <PackageManagement Include="StackExchange.Redis" Version="2.7.33" />
     <PackageManagement Include="StyleCop.Analyzers" Version="1.1.118" />
-    <PackageManagement Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
-    <PackageManagement Include="System.Linq.Async" Version="6.0.1" />
+    <PackageManagement Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
     <PackageManagement Include="System.IO.Hashing" Version="8.0.0" />
+    <PackageManagement Include="System.Linq.Async" Version="6.0.1" />
+    <PackageManagement Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageManagement Include="xunit" Version="2.7.0" />
     <PackageManagement Include="xunit.analyzers" Version="1.11.0" />
     <PackageManagement Include="xunit.runner.visualstudio" Version="2.5.7" />
-    <PackageManagement Include="YesSql" Version="5.0.0-beta-0002" />
-    <PackageManagement Include="YesSql.Abstractions" Version="5.0.0-beta-0002" />
-    <PackageManagement Include="YesSql.Core" Version="5.0.0-beta-0002" />
-    <PackageManagement Include="YesSql.Filters.Abstractions" Version="5.0.0-beta-0002" />
-    <PackageManagement Include="YesSql.Filters.Query" Version="5.0.0-beta-0002" />
+    <PackageManagement Include="YesSql" Version="5.0.0" />
+    <PackageManagement Include="YesSql.Abstractions" Version="5.0.0" />
+    <PackageManagement Include="YesSql.Core" Version="5.0.0" />
+    <PackageManagement Include="YesSql.Filters.Abstractions" Version="5.0.0" />
+    <PackageManagement Include="YesSql.Filters.Query" Version="5.0.0" />
     <PackageManagement Include="ZString" Version="2.6.0" />
   </ItemGroup>
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/ContentApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/ContentApiController.cs
@@ -7,7 +7,7 @@ using OrchardCore.Contents;
 namespace OrchardCore.Demo.Controllers
 {
     [Route("api/demo")]
-    [Authorize(AuthenticationSchemes = "Api"), IgnoreAntiforgeryToken, AllowAnonymous]
+    [Authorize(AuthenticationSchemes = "Api"), IgnoreAntiforgeryToken]
     [ApiController]
     public class ContentApiController : Controller
     {
@@ -20,6 +20,7 @@ namespace OrchardCore.Demo.Controllers
             _contentManager = contentManager;
         }
 
+        [AllowAnonymous]
         public async Task<IActionResult> GetById(string id)
         {
             var contentItem = await _contentManager.GetAsync(id);
@@ -32,6 +33,7 @@ namespace OrchardCore.Demo.Controllers
             return new ObjectResult(contentItem);
         }
 
+        [AllowAnonymous]
         public async Task<IActionResult> GetAuthorizedById(string id)
         {
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.DemoAPIAccess))

--- a/src/OrchardCore.Modules/OrchardCore.MiniProfiler/OrchardCore.MiniProfiler.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.MiniProfiler/OrchardCore.MiniProfiler.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" />
+    <PackageReference Include="System.Text.RegularExpressions" />
     <PackageReference Include="YesSql.Abstractions" />
   </ItemGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
@@ -522,8 +522,9 @@ namespace OrchardCore.OpenId.Services
                     var flags = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
                         X509KeyStorageFlags.EphemeralKeySet :
                         X509KeyStorageFlags.MachineKeySet;
-
+                    #pragma warning disable SYSLIB0057 // Warning disabled per https://github.com/dotnet/docs/issues/41662, TODO: Update to use X509CertificateLoader.LoadPkcs12FromFile we are able to use it (will need to version block with this regardless).
                     return new X509Certificate2(path, password, flags);
+                    #pragma warning restore SYSLIB0057
                 }
                 // Some cloud platforms (e.g Azure App Service/Antares) are known to fail to import .pfx files if the
                 // private key is not persisted or marked as exportable. To ensure X.509 certificates can be correctly
@@ -533,11 +534,12 @@ namespace OrchardCore.OpenId.Services
                 {
                     _logger.LogDebug(exception, "A first-chance exception occurred while trying to extract " +
                                                 "a X.509 certificate with the default key storage options.");
-
+                    #pragma warning disable SYSLIB0057 // Warning disabled per https://github.com/dotnet/docs/issues/41662, TODO: Update to use X509CertificateLoader.LoadPkcs12FromFile we are able to use it (will need to version block with this regardless).
                     return new X509Certificate2(path, password,
                         X509KeyStorageFlags.MachineKeySet |
                         X509KeyStorageFlags.PersistKeySet |
                         X509KeyStorageFlags.Exportable);
+                    #pragma warning restore SYSLIB0057
                 }
                 // Don't swallow exceptions thrown from the catch handler to ensure unrecoverable exceptions
                 // (e.g caused by malformed X.509 certificates or invalid password) are correctly logged.

--- a/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Irony.Core" />
+    <PackageReference Include="Irony" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCore.Data.YesSql.csproj
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCore.Data.YesSql.csproj
@@ -26,6 +26,7 @@
   <PackageReference Include="Azure.Identity"/>
   <PackageReference Include="Microsoft.Data.SqlClient" />
   <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+  <PackageReference Include="Npgsql" />
   <PackageReference Include="System.Drawing.Common" Version="6.0.0"/>
   <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   <PackageReference Include="YesSql" />


### PR DESCRIPTION
Update packages to get OrchardCore building again. Also fixed two build errors from using updated SDK including disabling SYSLIB0057 for X509Certificate2 initialization and specified AllowAnonymous attributes.