### PR TITLE
Update SixLabors.ImageSharp.Web dependency from 3.1.2 to 3.1.3.

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -65,7 +65,7 @@
     <PackageManagement Include="PdfPig" Version="0.1.8" />
     <PackageManagement Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageManagement Include="Shortcodes" Version="1.3.3" />
-    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="3.1.2" />
+    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="3.1.3" />
     <PackageManagement Include="StackExchange.Redis" Version="2.7.33" />
     <PackageManagement Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageManagement Include="System.Formats.Asn1" Version="8.0.1" />


### PR DESCRIPTION
Update SixLabors.ImageSharp.Web dependency from 3.1.2 to 3.1.3.