### PR TITLE
Remove GetKeyedService of specified type as .NET 10 implemented it as well

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceProviderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceProviderExtensions.cs
@@ -21,18 +21,4 @@ public static class ServiceProviderExtensions
     {
         return (TResult)ActivatorUtilities.CreateInstance(provider, type);
     }
-
-    /// <summary>
-    /// Gets the service object of the specified type with the specified key.
-    /// </summary>
-    public static object? GetKeyedService(this IServiceProvider provider, Type serviceType, object? serviceKey)
-    {
-        ArgumentNullException.ThrowIfNull(provider);
-        if (provider is IKeyedServiceProvider keyedServiceProvider)
-        {
-            return keyedServiceProvider.GetKeyedService(serviceType, serviceKey);
-        }
-
-        throw new InvalidOperationException("This service provider doesn't support keyed services.");
-    }
 }


### PR DESCRIPTION
Remove GetKeyedService of specified type as .NET 10 seems to have implemented the same method signature.
The warning that was being hit was: 
```
DotNet_OrchardCore\orchardcore\src\OrchardCore\OrchardCore.Abstractions\Shell\Scope\ShellScopeServices.cs(17,21): error CS0121: The call is ambiguous between the following methods or properties: 'Microsoft.Extensions.DependencyInjection.ServiceProviderKeyedServiceExtensions.GetKeyedService(System.IServiceProvider, System.Type, object?)' and 'OrchardCore.Environment.Shell.Builders.ServiceProviderExtensions.GetKeyedService(System.IServiceProvider, System.Type, object?)' [D:\a\_work\1\s\artifacts\out\DotNet_OrchardCore\orchardcore\src\OrchardCore\OrchardCore.Abstractions\OrchardCore.Abstractions.csproj::TargetFramework=net10.0]
```