### PR TITLE
Update SixLabors from 3.1.3 to 3.1.5.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,9 +58,9 @@
     <PackageVersion Include="OrchardCore.Translations.All" Version="2.1.0" />
     <PackageVersion Include="PdfPig" Version="0.1.9" />
     <PackageVersion Include="Shortcodes" Version="1.3.5" />
-    <PackageVersion Include="SixLabors.ImageSharp.Web" Version="3.1.3" />
-    <PackageVersion Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.1.3" />
-    <PackageVersion Include="SixLabors.ImageSharp.Web.Providers.AWS" Version="3.1.3" />
+    <PackageVersion Include="SixLabors.ImageSharp.Web" Version="3.1.5" />
+    <PackageVersion Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.1.5" />
+    <PackageVersion Include="SixLabors.ImageSharp.Web.Providers.AWS" Version="3.1.5" />
     <PackageVersion Include="StackExchange.Redis" Version="2.8.24" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />


### PR DESCRIPTION
Update SixLabors from version 3.1.3 to 3.1.5.